### PR TITLE
Add removeCallback function to emitter

### DIFF
--- a/Sparks.js
+++ b/Sparks.js
@@ -193,6 +193,10 @@ SPARKS.Emitter.prototype = {
         this.callbacks[name] = callback;
     },
     
+    removeCallback: function(name) {
+        delete this.callbacks[name];
+    },
+    
     dispatchEvent: function(name, args) {
         var callback = this.callbacks[name];
         if (callback) {


### PR DESCRIPTION
I've started implementing sparks.js into threenodes and needed a way to clean nodes after deleting them. Emitter already have an addCallback function so I figured it would be good to have its counterpart. 
