### PR TITLE
Minor fix for SPARKS.Engine.stop();

### DIFF
--- a/Sparks.js
+++ b/Sparks.js
@@ -45,8 +45,8 @@ SPARKS.Engine = {
 	
 	stop: function() {
 		this._isRunning = false;
-		for (var i=0,il=_emitters.length;i<il;i++) {
-			_emitters[i]._isRunning = false;
+		for (var i=0,il=this._emitters.length;i<il;i++) {
+			this._emitters[i]._isRunning = false;
 		}
 		clearTimeout(this._timer);
 	},


### PR DESCRIPTION
function previously referenced (non-existant) global _emitters rather than object propert this._emitters.

Prior to this fix, SPARKS.Engine.stop() errors out instead of stopping. 
With this fix, stop() works as expected the first time.
